### PR TITLE
Fixed mlmm argument

### DIFF
--- a/src/schnetpack/utils/script_utils/data.py
+++ b/src/schnetpack/utils/script_utils/data.py
@@ -206,7 +206,7 @@ def get_dataset(args, environment_provider, logging=None):
             load_only=load_only,
             collect_triples=args.model == "wacsf",
             environment_provider=environment_provider,
-            mlmm=args.mlmm_indices,
+            mlmm=args.mlmm,
         )
         return dataset
     else:

--- a/src/schnetpack/utils/script_utils/model.py
+++ b/src/schnetpack/utils/script_utils/model.py
@@ -120,7 +120,7 @@ def get_output_module(args, representation, mean, stddev, atomref):
             negative_dr=negative_dr,
             contributions=contributions,
             stress=stress,
-            mlmm = args.mlmm_indices,
+            mlmm = args.mlmm,
             n_layers=args.n_hlayers
         )
     elif output_module_str == "polarizability":

--- a/src/scripts/spk_run.py
+++ b/src/scripts/spk_run.py
@@ -128,10 +128,9 @@ def main(args):
     # load MLMM indices
     if args.mlmm is not None:
         mlmm_indices = get_indices_mlmm(args.mlmm) 
-        train_args.mlmm_indices = mlmm_indices
+        train_args.mlmm = mlmm_indices
     else:
-        args.mlmm_indices = None
-        train_args.mlmm_indices = None
+        train_args.mlmm = None
  
     # get dataset
     environment_provider = get_environment_provider(train_args, device=device)


### PR DESCRIPTION
`args.mlmm_indices` is not defined in the argparse section and raises exception, it is called `mlmm` instead.